### PR TITLE
Taggerdate->Creatordate + 1.0.3

### DIFF
--- a/lib/fastlane/plugin/develappers/actions/app_version_action.rb
+++ b/lib/fastlane/plugin/develappers/actions/app_version_action.rb
@@ -20,7 +20,7 @@ module Fastlane
           `git fetch --tags`
 
           tag_name = `git describe --tags --match "#{tag_prefix}/*" --abbrev=0`.strip!
-          tag_name_with_build_number = `git tag --sort=taggerdate -l "#{tag_prefix}/*-*" | tail -n1`.strip!
+          tag_name_with_build_number = `git tag --sort=creatordate -l "#{tag_prefix}/*-*" | tail -n1`.strip!
           
           unless tag_name.nil? 
             UI.message "Tag '#{tag_name}' found"

--- a/lib/fastlane/plugin/develappers/actions/app_version_action.rb
+++ b/lib/fastlane/plugin/develappers/actions/app_version_action.rb
@@ -16,9 +16,6 @@ module Fastlane
           # prev. version tag in git
           UI.message "Searching Tag matching '#{tag_prefix}/*'"
 
-          `git tag -d $(git tag -l "#{tag_prefix}/*")`
-          `git fetch --tags`
-
           tag_name = `git describe --tags --match "#{tag_prefix}/*" --abbrev=0`.strip!
           tag_name_with_build_number = `git tag --sort=taggerdate -l "#{tag_prefix}/*-*" | tail -n1`.strip!
           

--- a/lib/fastlane/plugin/develappers/version.rb
+++ b/lib/fastlane/plugin/develappers/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Develappers
-    VERSION = '0.1.2'
+    VERSION = '1.0.3'
   end
 end


### PR DESCRIPTION
Taggerdate macht leider Probleme und ich habe mir den Unterschied zwischen beiden durchgelesen und ich denke Creatordate ist richtig. Taggerdate liefert leider falsche Ergebnisse(wenn Tags direkt auf Gitlab erstellt werden), weswegen ich es auch schon im Android Plugin umgestellt habe vor einigen Tagen und daraufhin haben die Build-Nummern gestimmt. Das löschen der Tags + git fetch habe ich auch rausgenommen, da dies kein Problem ist, wenn für jede Version die Pipeline neu erstellt wird, anstatt eine bestehende Pipeline neuanzustoßen. Beim Android Plugin wird das löschen+fetch auch nicht gemacht.