### PR TITLE
Largest Build-Number + Import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+dotenv
 gemspec
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')

--- a/lib/fastlane/plugin/develappers/actions/app_version_action.rb
+++ b/lib/fastlane/plugin/develappers/actions/app_version_action.rb
@@ -26,7 +26,7 @@ module Fastlane
 
           unless tag_name_with_build_number.nil?
             UI.message "Tag with latest build number '#{tag_name_with_build_number}' found" 
-            match_build_number = tag_name_with_build_number.match(%r{^.*-(\d*)$}s)
+            match_build_number = tag_name_with_build_number.match(%r{^(\d*)$}s)
           end
 
           if match.nil?

--- a/lib/fastlane/plugin/develappers/actions/app_version_action.rb
+++ b/lib/fastlane/plugin/develappers/actions/app_version_action.rb
@@ -17,7 +17,7 @@ module Fastlane
           UI.message "Searching Tag matching '#{tag_prefix}/*'"
 
           tag_name = `git describe --tags --match "#{tag_prefix}/*" --abbrev=0`.strip!
-          tag_name_with_build_number = `git tag --sort=creatordate -l "#{tag_prefix}/*-*" | tail -n1`.strip!
+          tag_name_with_build_number = `git tag -l "#{tag_prefix}/*-*" | cut -d '-' -f2 | sort -n | tail -n1`.strip!
           
           unless tag_name.nil? 
             UI.message "Tag '#{tag_name}' found"

--- a/lib/fastlane/plugin/develappers/actions/app_version_action.rb
+++ b/lib/fastlane/plugin/develappers/actions/app_version_action.rb
@@ -1,3 +1,5 @@
+require 'dotenv'
+
 module Fastlane
   module Actions
     class AppVersionAction < Action
@@ -9,9 +11,10 @@ module Fastlane
         tag_prefix = 'iOS'
         tag_prefix = "iOS/#{flavor.downcase}" unless flavor.nil?
 
+        should_import = !params[:import_file].nil?
         should_export = !params[:export_file].nil?
 
-        if !output.eql?('code') || should_export
+        if !should_import && (!output.eql?('code') || should_export)
 
           # prev. version tag in git
           UI.message "Searching Tag matching '#{tag_prefix}/*'"
@@ -44,6 +47,14 @@ module Fastlane
             build = match_build_number[1].to_i + 1
             UI.message "Build number is #{build} because of last tag with build number #{tag_name_with_build_number}"
           end
+        elsif should_import
+            Dotenv.load(import_file)
+
+            import_prefix = params[:import_prefix]
+
+            version_name = ENV["#{import_prefix}VERSION_NAME"]
+            build = ENV["#{import_prefix}VERSION_CODE"]
+            tag_name = ENV["#{import_prefix}TAG_NAME"]
         end
 
         tag_name = "#{tag_prefix}/#{version_name}-#{build}" if !output.eql?('tagname') || should_export
@@ -108,6 +119,15 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :export_prefix,
                                        description: 'Prefix for env vars in exported file',
+                                       type: String,
+                                       optional: true,
+                                       default_value: ''),
+          FastlaneCore::ConfigItem.new(key: :import_file,
+                                       description: 'Import version name and version code from a file, instead of creating new ones from the git history.',
+                                       type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :import_prefix,
+                                       description: 'Prefix for env vars in imported file',
                                        type: String,
                                        optional: true,
                                        default_value: '')

--- a/lib/fastlane/plugin/develappers/actions/app_version_action.rb
+++ b/lib/fastlane/plugin/develappers/actions/app_version_action.rb
@@ -123,7 +123,7 @@ module Fastlane
                                        optional: true,
                                        default_value: ''),
           FastlaneCore::ConfigItem.new(key: :import_file,
-                                       description: 'Import version name and version code from a file, instead of creating new ones from the git history.',
+                                       description: 'Import version name and version code from a file, instead of creating new ones from the git history',
                                        type: String,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :import_prefix,

--- a/lib/fastlane/plugin/develappers/actions/app_version_action.rb
+++ b/lib/fastlane/plugin/develappers/actions/app_version_action.rb
@@ -48,7 +48,7 @@ module Fastlane
             UI.message "Build number is #{build} because of last tag with build number #{tag_name_with_build_number}"
           end
         elsif should_import
-            Dotenv.load(import_file)
+            Dotenv.load(params[:import_file])
 
             import_prefix = params[:import_prefix]
 

--- a/lib/fastlane/plugin/develappers/version.rb
+++ b/lib/fastlane/plugin/develappers/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Develappers
-    VERSION = '1.0.3'
+    VERSION = '1.0.4'
   end
 end


### PR DESCRIPTION
Instead of searching the latest tag with a build number now the build number, which is  the largest, will be used.
It is now possible to import the version_name, version_code and tag_name to use.